### PR TITLE
Add DocC documentation articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The package provides five targets across four library products:
 ## Dependencies
 
 Internally, the package uses [Point Free's Dependencies](https://github.com/pointfreeco/swift-dependencies) in order
-to support the ability for the TMDB framework to provide real data when run in Testing or SwiftUI Preview environments.
+to support the ability for the TMDB framework to provide mock data when run in Testing or SwiftUI Preview environments.
 
 ## Advanced Usage
 

--- a/Sources/TMDB/Documentation.docc/Articles/AccountAndLists.md
+++ b/Sources/TMDB/Documentation.docc/Articles/AccountAndLists.md
@@ -1,0 +1,125 @@
+# Account and Lists
+
+Manage favorites, watchlists, ratings, and custom lists for authenticated users.
+
+## Overview
+
+All operations in this article require authentication. See <doc:AuthenticationGuide> to set up a user session first.
+
+## Favorites and Watchlist
+
+Add or remove movies and TV series from a user's favorites or watchlist using ``TMDB/Account/MediaType`` to specify the media kind.
+
+```swift
+// Add a movie to favorites
+try await TMDB.setFavorite(mediaType: .movie, mediaID: 550, favorite: true)
+
+// Remove a TV series from favorites
+try await TMDB.setFavorite(mediaType: .tv, mediaID: 1396, favorite: false)
+
+// Add to watchlist
+try await TMDB.setWatchlist(mediaType: .movie, mediaID: 550, watchlist: true)
+```
+
+## Ratings
+
+Rate movies and TV on a scale of 0.5 to 10.0 (in 0.5 increments).
+
+```swift
+// Rate a movie
+try await TMDB.rateMovie(id: 550, rating: 8.5)
+
+// Delete a rating
+try await TMDB.deleteMovieRating(id: 550)
+
+// Rate a TV series
+try await TMDB.rateTVSeries(id: 1396, rating: 9.0)
+
+// Rate a specific episode
+try await TMDB.rateTVEpisode(
+    seriesID: 1396,
+    seasonNumber: 1,
+    episodeNumber: 1,
+    rating: 9.5
+)
+```
+
+## Reading Account Data
+
+Fetch paginated lists of a user's favorites, ratings, watchlist, and recommendations.
+
+```swift
+let favorites = try await TMDB.favoriteMovies()
+let rated = try await TMDB.ratedMovies()
+let watchlist = try await TMDB.watchlistMovies()
+let recommendations = try await TMDB.accountMovieRecommendations()
+
+// With sorting and pagination
+let sortedFavorites = try await TMDB.favoriteMovies(
+    sortBy: .createdAtDescending,
+    page: 2
+)
+```
+
+## Lists
+
+Create and manage custom lists using the v4 API.
+
+```swift
+// Create a list
+let result = try await TMDB.createList(
+    name: "My Favorites",
+    description: "A collection of my all-time favorites"
+)
+let listID = result.id
+
+// Add items (each item is a tuple of media type, ID, and optional comment)
+try await TMDB.addItemsToList(listID: listID, items: [
+    (mediaType: .movie, mediaID: 550, comment: "Classic"),
+    (mediaType: .tv, mediaID: 1396, comment: nil),
+])
+
+// View list details
+let details = try await TMDB.listDetails(listID: listID)
+
+// Check if an item is in the list
+let status = try await TMDB.listItemStatus(
+    listID: listID,
+    mediaType: .movie,
+    mediaID: 550
+)
+
+// Remove items
+try await TMDB.removeItemsFromList(listID: listID, items: [
+    (mediaType: .movie, mediaID: 550),
+])
+
+// Clear all items
+try await TMDB.clearList(listID: listID)
+
+// Delete the list
+try await TMDB.deleteList(listID: listID)
+```
+
+## Guest Sessions
+
+Guest sessions allow unauthenticated users to rate content. Ratings are stored temporarily on TMDB's servers.
+
+```swift
+// Create a guest session
+let guestSession = try await TMDB.createGuestSession()
+let sessionID = guestSession.guestSessionID
+
+// Rate a movie as a guest
+try await TMDB.guestRateMovie(
+    id: 550,
+    rating: 7.5,
+    guestSessionID: sessionID
+)
+
+// Retrieve guest-rated movies
+let rated = try await TMDB.guestRatedMovies(sessionID: sessionID)
+
+// Delete a guest rating
+try await TMDB.guestDeleteMovieRating(id: 550, guestSessionID: sessionID)
+```

--- a/Sources/TMDB/Documentation.docc/Articles/AuthenticationGuide.md
+++ b/Sources/TMDB/Documentation.docc/Articles/AuthenticationGuide.md
@@ -1,0 +1,104 @@
+# Authentication
+
+Authenticate users with TMDB to enable account features, lists, and ratings.
+
+## Overview
+
+Authentication unlocks account-level features: managing favorites and watchlists, rating movies and TV shows, and creating lists. `swift-tmdb` provides platform-specific helpers for SwiftUI and UIKit, plus a manual flow for custom UIs.
+
+## SwiftUI
+
+Import `TMDBSwiftUI` and use the `.tmdbAuthentication` view modifier. It presents a browser-based OAuth flow and returns the result.
+
+```swift
+import SwiftUI
+import TMDBSwiftUI
+
+struct SettingsView: View {
+    @State private var showAuth = false
+
+    var body: some View {
+        Button("Sign In with TMDB") {
+            showAuth = true
+        }
+        .tmdbAuthentication(isPresented: $showAuth) { result in
+            switch result {
+            case .success(let session):
+                print("Authenticated: \(session.accountID)")
+            case .failure(let error):
+                print("Auth failed: \(error)")
+            }
+        }
+    }
+}
+```
+
+## UIKit
+
+Import `TMDBUIKit` and call `TMDB.authenticate(presentationAnchor:)` from a view controller.
+
+```swift
+import UIKit
+import TMDBUIKit
+
+class SettingsViewController: UIViewController {
+    @IBAction func signInTapped(_ sender: Any) {
+        Task {
+            do {
+                let session = try await TMDB.authenticate(
+                    presentationAnchor: view.window!
+                )
+                print("Authenticated: \(session.accountID)")
+            } catch {
+                print("Auth failed: \(error)")
+            }
+        }
+    }
+}
+```
+
+## Manual Flow
+
+For custom UIs, use ``TMDB/AuthenticationCoordinator`` directly. This gives you control over each step of the OAuth flow.
+
+```swift
+let coordinator = TMDB.AuthenticationCoordinator()
+
+// Step 1: Create a request token and get the approval URL
+let (requestToken, approvalURL) = try await coordinator.createRequestToken()
+
+// Step 2: Open approvalURL in a browser for the user to approve
+// When the browser redirects back to your app with a URL...
+
+// Step 3: Complete authentication with the redirect URL
+let session = try await coordinator.authenticate(browserRedirectURL: redirectURL)
+print("Access token: \(session.accessToken)")
+print("Account ID: \(session.accountID)")
+```
+
+## Logout
+
+```swift
+try await TMDB.logout()
+```
+
+This deletes the v4 access token, v3 session, and clears the keychain.
+
+## Checking Auth State
+
+Use ``TMDB/isAuthenticated`` and ``TMDB/currentSession`` to check the current state:
+
+```swift
+if TMDB.isAuthenticated {
+    let session = TMDB.currentSession
+    print("Logged in as \(session?.accountID ?? "")")
+}
+```
+
+The ``TMDB/AuthSession`` struct provides the authenticated user's credentials:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `accessToken` | `String` | v4 API access token |
+| `accountID` | `String` | TMDB account identifier |
+| `sessionID` | `String?` | v3 session ID (if converted) |

--- a/Sources/TMDB/Documentation.docc/Articles/DiscoverFilters.md
+++ b/Sources/TMDB/Documentation.docc/Articles/DiscoverFilters.md
@@ -1,0 +1,103 @@
+# Discover Filters
+
+Build type-safe, composable queries for the TMDB Discover endpoint.
+
+## Overview
+
+The Discover endpoint supports complex filtering through ``TMDB/Discover/MovieFilter`` and ``TMDB/Discover/TVFilter``. Filters are passed as variadic arguments — combine as many as you need.
+
+## Basic Usage
+
+```swift
+// Discover popular action movies
+let results = try await TMDB.discoverMovie(
+    filters:
+    .withGenres([.and("28")]),
+    .sortBy(.popularity, .descending)
+)
+
+// Discover no filters (returns default results)
+let defaults = try await TMDB.discoverMovie()
+```
+
+## Logical Operators
+
+Some filters accept arrays of ``TMDB/Discover/LogicalOperator`` values. Use `.and()` for "all of these" and `.or()` for "any of these".
+
+```swift
+// Movies in BOTH Action (28) AND Comedy (35) genres
+// Query: with_genres=28,35
+.withGenres([.and("28"), .and("35")])
+
+// Movies in EITHER Action (28) OR Comedy (35)
+// Query: with_genres=28|35
+.withGenres([.or("28"), .or("35")])
+```
+
+## Movie Filters
+
+All cases on ``TMDB/Discover/MovieFilter``:
+
+| Category | Filters |
+|----------|---------|
+| **Sorting** | `sortBy` |
+| **Pagination** | `page`, `language`, `region` |
+| **Dates** | `primaryReleaseDateGreaterThan`, `primaryReleaseDateLessThan`, `releaseDateGreaterThan`, `releaseDateLessThan`, `primaryReleaseYear`, `year` |
+| **Ratings** | `voteAverageGreaterThan`, `voteAverageLessThan`, `voteCountGreaterThan`, `voteCountLessThan` |
+| **Genres** | `withGenres`, `withoutGenres` |
+| **Keywords** | `withKeywords`, `withoutKeywords` |
+| **Cast & Crew** | `withCast`, `withCrew`, `withPeople` |
+| **Companies** | `withCompanies`, `withoutCompanies` |
+| **Certification** | `certification`, `certificationCountry`, `certificationGreaterThan`, `certificationLessThan` |
+| **Release Type** | `withReleaseType` |
+| **Runtime** | `withRuntimeGreaterThan`, `withRuntimeLessThan` |
+| **Watch** | `withWatchProviders`, `withWatchMonetizationTypes`, `watchRegion` |
+| **Content** | `includeAdult`, `includeVideo` |
+| **Origin** | `withOriginCountry`, `withOriginalLanguage` |
+
+## TV Filters
+
+All cases on ``TMDB/Discover/TVFilter``:
+
+| Category | Filters |
+|----------|---------|
+| **Sorting** | `sortBy` |
+| **Pagination** | `page`, `language` |
+| **Air Dates** | `airDateGreaterThan`, `airDateLessThan`, `firstAirDateGreaterThan`, `firstAirDateLessThan`, `firstAirDateYear`, `includeNullFirstAirDates` |
+| **Ratings** | `voteAverageGreaterThan`, `voteAverageLessThan`, `voteCountGreaterThan`, `voteCountLessThan` |
+| **Genres** | `withGenres`, `withoutGenres` |
+| **Keywords** | `withKeywords`, `withoutKeywords` |
+| **Networks** | `withNetworks` |
+| **Companies** | `withCompanies`, `withoutCompanies` |
+| **Status** | `withStatus`, `withType` |
+| **Runtime** | `withRuntimeGreaterThan`, `withRuntimeLessThan` |
+| **Watch** | `withWatchProviders`, `withWatchMonetizationTypes`, `watchRegion` |
+| **Content** | `includeAdult`, `screenedTheatrically` |
+| **Origin** | `withOriginCountry`, `withOriginalLanguage`, `timezone` |
+
+## Combining Filters
+
+Build complex queries by combining multiple filters:
+
+```swift
+// Highly-rated sci-fi movies from 2024 with a runtime over 2 hours
+let results = try await TMDB.discoverMovie(
+    filters:
+    .withGenres([.and("878")]),
+    .primaryReleaseYear(2024),
+    .voteAverageGreaterThan(7.0),
+    .voteCountGreaterThan(100),
+    .withRuntimeGreaterThan(120),
+    .sortBy(.voteAverage, .descending)
+)
+```
+
+```swift
+// TV series currently airing with high ratings
+let tvResults = try await TMDB.discoverTV(
+    filters:
+    .withStatus([.and(.returningSeries)]),
+    .voteAverageGreaterThan(8.0),
+    .sortBy(.popularity, .descending)
+)
+```

--- a/Sources/TMDB/Documentation.docc/Articles/ErrorHandling.md
+++ b/Sources/TMDB/Documentation.docc/Articles/ErrorHandling.md
@@ -1,0 +1,72 @@
+# Error Handling
+
+Handle errors from TMDB API requests using typed throws.
+
+## Overview
+
+All public methods on `TMDB` use `async throws(TMDBRequestError)`, giving you exhaustive error handling at compile time.
+
+## TMDBRequestError
+
+The primary error type thrown by all API methods.
+
+| Case | Description |
+|------|-------------|
+| `.networkError(TMDBAPIError)` | HTTP-level error from the TMDB API |
+| `.systemError(any Error)` | Unexpected error (URL session failure, decoding error, etc.) |
+| `.notAuthenticated` | Operation requires authentication but no session exists |
+| `.authenticationCancelled` | User cancelled the browser-based auth flow |
+| `.authenticationAlreadyInProgress` | Another auth flow is already active |
+| `.imageConfigurationMissing` | Image configuration not yet loaded (call `TMDB.initialize` first) |
+| `.unsupportedImageSize` | Requested image size not available for this image type |
+
+## Handling Errors
+
+```swift
+do {
+    let movie = try await TMDB.movieDetails(id: 550)
+} catch .networkError(let apiError) {
+    // HTTP error from TMDB (4xx or 5xx)
+    print("API error: \(apiError)")
+} catch .notAuthenticated {
+    // Prompt user to sign in
+    showSignIn = true
+} catch .systemError(let underlying) {
+    // Network failure, decoding error, etc.
+    print("System error: \(underlying)")
+} catch {
+    print("Other error: \(error)")
+}
+```
+
+## TMDBInitializationError
+
+Thrown by ``TMDB/initialize(apiKey:urlSessionConfiguration:)`` and ``TMDB/initialize(configuration:)``.
+
+| Case | Description |
+|------|-------------|
+| `.alreadyInitialized` | `initialize` was called more than once |
+| `.notYetInitialized` | An API call was made before `initialize` |
+| `.configurationFetchFailed` | The initial configuration fetch from TMDB failed |
+
+## TMDBAPIError
+
+The HTTP-level error type wrapped by `TMDBRequestError.networkError`.
+
+| Case | Description |
+|------|-------------|
+| `.invalidResponseFromServer` | Response was not a valid HTTP response |
+| `.clientError(HTTPURLResponse, Data)` | 4xx status code (unauthorized, not found, etc.) |
+| `.serverError(HTTPURLResponse, Data)` | 5xx status code (TMDB server error) |
+
+Extract the HTTP status code from a client error:
+
+```swift
+catch .networkError(.clientError(let response, _)) {
+    switch response.statusCode {
+    case 401: print("Invalid API key")
+    case 404: print("Resource not found")
+    default: print("Client error: \(response.statusCode)")
+    }
+}
+```

--- a/Sources/TMDB/Documentation.docc/Articles/TestingAndPreviews.md
+++ b/Sources/TMDB/Documentation.docc/Articles/TestingAndPreviews.md
@@ -1,0 +1,94 @@
+# Testing and Previews
+
+Use automatic mock data in unit tests and SwiftUI previews with zero configuration.
+
+## Overview
+
+`swift-tmdb` provides mock data automatically in test and preview contexts using [PointFree's Dependencies](https://github.com/pointfreeco/swift-dependencies). No setup or registration is needed — just call TMDB methods as normal.
+
+## Unit Test Example
+
+Tests can call any TMDB method directly. Mock data is returned instantly.
+
+```swift
+import Testing
+@testable import TMDB
+
+struct MovieTests {
+    @Test func movieDetailsReturnsValidData() async throws {
+        let movie = try await TMDB.movieDetails(id: 550)
+        #expect(movie.title == "Fight Club")
+        #expect(movie.id == 550)
+    }
+}
+```
+
+## Using MockableResponse
+
+For direct access to mock models without making an API call, import `TMDBMocking` and use the `mock()` convenience method.
+
+```swift
+import Testing
+import TMDB
+import TMDBMocking
+
+struct ModelTests {
+    @Test func movieMockHasExpectedValues() {
+        let movie = TMDB.Movie.mock()
+        #expect(!movie.title.isEmpty)
+    }
+}
+```
+
+## SwiftUI Previews
+
+Previews work identically to production code. Mock data is returned automatically with a 2-second delay to simulate realistic loading.
+
+```swift
+import SwiftUI
+import TMDB
+
+#Preview {
+    MovieListView()
+}
+
+struct MovieListView: View {
+    @State private var movies: [TMDB.Discover.DiscoverMovie] = []
+
+    var body: some View {
+        List(movies, id: \.id) { movie in
+            Text(movie.title)
+        }
+        .task {
+            let results = try? await TMDB.searchMovies(query: "Matrix")
+            movies = results?.results ?? []
+        }
+    }
+}
+```
+
+## Dependency Overrides
+
+For custom test doubles, use `withDependencies` to override the HTTP client or other internals.
+
+```swift
+import Testing
+import Dependencies
+@testable import TMDB
+
+struct CustomMockTests {
+    @Test func customOverride() async throws {
+        try await withDependencies {
+            $0.httpClient = .init(
+                data: { _ in
+                    // Return custom mock data
+                    (customJSON, HTTPURLResponse())
+                }
+            )
+        } operation: {
+            let movie = try await TMDB.movieDetails(id: 1)
+            #expect(movie.title == "Custom Title")
+        }
+    }
+}
+```

--- a/Sources/TMDB/Documentation.docc/Articles/Usage.md
+++ b/Sources/TMDB/Documentation.docc/Articles/Usage.md
@@ -113,7 +113,7 @@ let results = try await TMDB.searchMovies(query: "Inception")
 let trending = try await TMDB.trendingAll(timeWindow: .week)
 
 // Discover with filters
-let action = try await TMDB.discoverMovie(filters: [.withGenres([.and("28")]), .sortBy(.popularity, .descending)])
+let action = try await TMDB.discoverMovie(filters: .withGenres([.and("28")]), .sortBy(.popularity, .descending))
 ```
 
 Calling these methods is safe from SwiftUI Previews and unit tests. `swift-tmdb` uses [PointFree's Dependencies](https://github.com/pointfreeco/swift-dependencies) to provide mock data automatically.

--- a/Sources/TMDB/Documentation.docc/TMDB.md
+++ b/Sources/TMDB/Documentation.docc/TMDB.md
@@ -13,6 +13,11 @@ Supports movies, TV series, seasons, episodes, search, discover, trending, authe
 ### Getting Started
 
 - <doc:Usage>
+- <doc:AuthenticationGuide>
+- <doc:ErrorHandling>
+- <doc:TestingAndPreviews>
+- <doc:AccountAndLists>
+- <doc:DiscoverFilters>
 - ``TMDB``
 - ``TMDBConfiguration``
 
@@ -186,6 +191,9 @@ Supports movies, TV series, seasons, episodes, search, discover, trending, authe
 - ``TMDB/deleteAccessToken(_:)``
 - ``TMDB/convertToV3Session(accessToken:)``
 - ``TMDB/deleteV3Session(sessionID:)``
+- ``TMDB/logout()``
+- ``TMDB/isAuthenticated``
+- ``TMDB/currentSession``
 - ``TMDB/AuthenticationCoordinator``
 
 ### Account
@@ -388,6 +396,7 @@ Supports movies, TV series, seasons, episodes, search, discover, trending, authe
 - ``TMDB/TVCertifications``
 - ``TMDB/WatchProvider``
 - ``TMDB/WatchProviderRegion``
+- ``TMDB/WatchProviderList``
 - ``TMDB/Credits/Details``
 - ``TMDB/ProductionCompany``
 - ``TMDB/TitleCollection``
@@ -396,6 +405,7 @@ Supports movies, TV series, seasons, episodes, search, discover, trending, authe
 
 - ``TMDB/TrendingTimeWindow``
 - ``TMDB/ExternalSource``
+- ``TMDB/LoggingLevel``
 
 ### Codable Property Wrappers
 

--- a/Sources/TMDB/Models/Endpoints/Discover/Query Parameters/DiscoverTVFilter.swift
+++ b/Sources/TMDB/Models/Endpoints/Discover/Query Parameters/DiscoverTVFilter.swift
@@ -3,7 +3,7 @@ import Foundation
 public extension TMDB.Discover {
     /// Filters which can be included in the ``TMDB/discoverTV(filters:)`` method to filter your TMDB API request
     ///
-    /// See [TMDB's developer documentation](https://developer.themoviedb.org/reference/discover-movie) for details.
+    /// See [TMDB's developer documentation](https://developer.themoviedb.org/reference/discover-tv) for details.
     ///
     /// The filters will be added as URL query parameters in the order they're included in the parameter list.
     ///
@@ -14,8 +14,8 @@ public extension TMDB.Discover {
     /// For example, both of these filter lists will result in a final url query parameter of
     /// `with_release_type=4,5`
     /// ```swift
-    /// try await TMDB.discoverMovie(filters: .withReleaseType([.and(.digital), .and(.physical)]))
-    /// try await TMDB.discoverMovie(filters: .withReleaseType([.or(.digital), .and(.physical)]))
+    /// try await TMDB.discoverTV(filters: .withReleaseType([.and(.digital), .and(.physical)]))
+    /// try await TMDB.discoverTV(filters: .withReleaseType([.or(.digital), .and(.physical)]))
     /// ```
     enum TVFilter {
 


### PR DESCRIPTION
## Summary
- Add 5 new DocC articles covering documentation gaps: AuthenticationGuide, ErrorHandling, TestingAndPreviews, AccountAndLists, and DiscoverFilters
- Link all new articles from the Getting Started section in TMDB.md
- Fix DiscoverTVFilter formatting and update README/Usage.md

## Test plan
- [ ] `swift build` passes
- [ ] `swift package --disable-sandbox generate-documentation --target TMDB` generates with zero warnings
- [ ] All `<doc:>` links resolve correctly in the generated documentation
- [ ] Code examples in articles use correct method signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)