### PR TITLE
Add public TMDB.logout() static method

### DIFF
--- a/Sources/TMDB/Services/AuthService/TMDB+Auth.swift
+++ b/Sources/TMDB/Services/AuthService/TMDB+Auth.swift
@@ -12,4 +12,10 @@ public extension TMDB {
         @Dependency(\.authSessionStore) var sessionStore
         return sessionStore.load()
     }
+
+    /// Logs out the current user by deleting the v4 access token, v3 session, and clearing the keychain
+    static func logout() async throws(TMDBRequestError) {
+        let coordinator = AuthenticationCoordinator()
+        try await coordinator.logout()
+    }
 }

--- a/Tests/TMDBTests/Endpoint Tests/Auth/AuthEndpointTests.swift
+++ b/Tests/TMDBTests/Endpoint Tests/Auth/AuthEndpointTests.swift
@@ -37,6 +37,12 @@ struct AuthEndpointTests {
         #expect(result.success)
     }
 
+    // MARK: - Logout
+
+    @Test func logout() async throws {
+        try await TMDB.logout()
+    }
+
     // MARK: - URL Generation
 
     @Test func createRequestTokenURL() {


### PR DESCRIPTION
## Summary
- Adds `TMDB.logout()` public static method to match existing `TMDB.isAuthenticated` and `TMDB.currentSession` API surface
- Creates an `AuthenticationCoordinator` internally and delegates to its `logout()` method
- Adds unit test verifying `TMDB.logout()` completes without error

Closes #7

## Test plan
- [x] `swift build` compiles all 5 targets
- [x] `TMDB.logout()` test passes
- [x] `swiftformat` reports no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)