### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number (e.g., 1.2.0)'
+        required: true
+        type: string
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: macos-26
+    if: github.ref == 'refs/heads/main'
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Run Unit Tests
+        run: swift test --filter TMDBTests
+
+  integration-tests:
+    name: Integration Tests
+    needs: unit-tests
+    runs-on: macos-26
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Run Integration Tests
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: swift test --filter TMDBIntegrationTests
+
+  release:
+    name: Generate Docs & Create Release
+    needs: integration-tests
+    runs-on: macos-26
+    timeout-minutes: 20
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Generate Documentation
+        run: make docs
+
+      - name: Commit Documentation
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/
+          if git diff --cached --quiet; then
+            echo "No documentation changes to commit"
+          else
+            git commit -m "Update documentation for ${{ inputs.version }}"
+            git push
+          fi
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ inputs.version }}" \
+            --target main \
+            --title "${{ inputs.version }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch`-triggered release workflow to `.github/workflows/release.yml`
- Runs unit tests, then integration tests, then generates docs and creates a GitHub release
- Each job gates on the previous — failure stops the pipeline

## Workflow

1. **Unit Tests** (`macos-26`) — `swift test --filter TMDBTests`
2. **Integration Tests** (`macos-26`) — `swift test --filter TMDBIntegrationTests` with `TMDB_API_KEY` secret
3. **Docs & Release** (`macos-26`) — `make docs`, commit docs to main, `gh release create` with `--generate-notes`

## Details

- Only triggerable from `main`
- Version input as plain semver (e.g., `1.2.0`) used as git tag
- Docs commit is conditional (skipped if no changes)
- Release notes auto-generated from PR titles

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)