### PR TITLE
Register with Swift Package Index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: macos-26
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Run Unit Tests
+        run: swift test --filter TMDBTests

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,8 @@
+version: 1
+builder:
+  configs:
+  - documentation_targets:
+    - TMDB
+    - TMDBDependencies
+    - TMDBSwiftUI
+    - TMDBUIKit

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 ```
-           ▗▄▄▖▄   ▄ ▄ ▗▞▀▀▘■      ▗▄▄▄▖▗▖  ▗▖▗▄▄▄  ▗▄▄▖
-          ▐▌   █ ▄ █ ▄ ▐▌▗▄▟▙▄▖      █  ▐▛▚▞▜▌▐▌  █ ▐▌ ▐▌
-           ▝▀▚▖█▄█▄█ █ ▐▛▀▘▐▌        █  ▐▌  ▐▌▐▌  █ ▐▛▀▚▖
-          ▗▄▄▞▘      █ ▐▌  ▐▌        █  ▐▌  ▐▌▐▙▄▄▀ ▐▙▄▞▘
-                           ▐▌
-
+ ▗▄▄▖▄   ▄ ▄ ▗▞▀▀▘■      ▗▄▄▄▖▗▖  ▗▖▗▄▄▄  ▗▄▄▖
+▐▌   █ ▄ █ ▄ ▐▌▗▄▟▙▄▖      █  ▐▛▚▞▜▌▐▌  █ ▐▌ ▐▌
+ ▝▀▚▖█▄█▄█ █ ▐▛▀▘▐▌        █  ▐▌  ▐▌▐▌  █ ▐▛▀▚▖
+▗▄▄▞▘      █ ▐▌  ▐▌        █  ▐▌  ▐▌▐▙▄▄▀ ▐▙▄▞▘
+                 ▐▌
 ```
 
 # `swift-tmdb`: A Modern TMDB Swift Package
 
 A TMDB SDK that targets iOS/iPadOS 26 and uses Swift 6.2 and provides automatic mocked responses during unit testing
 and in SwiftUI Previews.
+
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fbrettohland%2Fswift-tmdb%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/brettohland/swift-tmdb)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fbrettohland%2Fswift-tmdb%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/brettohland/swift-tmdb)
+
+[![CI](https://github.com/brettohland/swift-tmdb/actions/workflows/ci.yml/badge.svg)](https://github.com/brettohland/swift-tmdb/actions/workflows/ci.yml)
+[![Integration Tests](https://github.com/brettohland/swift-tmdb/actions/workflows/integration.yml/badge.svg)](https://github.com/brettohland/swift-tmdb/actions/workflows/integration.yml)
 
 [swift-tmdb Documentation](https://brettohland.github.io/swift-tmdb/documentation/tmdb/)
 


### PR DESCRIPTION
Closes #13

## Summary

- Add `.spi.yml` to configure documentation targets for SPI (`TMDB`, `TMDBDependencies`, `TMDBSwiftUI`, `TMDBUIKit`)
- Add `ci.yml` workflow that runs unit tests on every push and PR to `main`
- Add CI, Integration Tests, Swift versions, and platforms badges to README

## After merging

Submit the package URL at https://swiftpackageindex.com/add-a-package
