### PR TITLE
Fix ASWebAuthenticationSession init on iOS 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         include:
           - platform: iOS
@@ -58,4 +59,5 @@ jobs:
           xcodebuild build \
             -scheme swift-tmdb-Package \
             -destination '${{ matrix.destination }}' \
-            -derivedDataPath .build/DerivedData
+            -derivedDataPath .build/DerivedData \
+            -skipMacroValidation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,35 @@ jobs:
 
       - name: Run Unit Tests
         run: swift test --filter TMDBTests
+
+  build:
+    name: Build (${{ matrix.platform }})
+    runs-on: macos-26
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        include:
+          - platform: iOS
+            destination: generic/platform=iOS Simulator
+          - platform: tvOS
+            destination: generic/platform=tvOS Simulator
+          - platform: macCatalyst
+            destination: generic/platform=macOS,variant=Mac Catalyst
+          - platform: macOS
+            destination: generic/platform=macOS
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Build (${{ matrix.platform }})
+        run: |
+          xcodebuild build \
+            -scheme swift-tmdb-Package \
+            -destination '${{ matrix.destination }}' \
+            -derivedDataPath .build/DerivedData

--- a/Sources/TMDB/Models/Endpoints/Auth/V4AuthEndpoints.swift
+++ b/Sources/TMDB/Models/Endpoints/Auth/V4AuthEndpoints.swift
@@ -32,8 +32,10 @@ public extension TMDB {
     /// - Parameter redirectTo: The URL to redirect to after the user approves the request token
     /// - Returns: ``TMDB/Auth/RequestToken``
     /// - Throws: ``TMDBRequestError``
-    static func createRequestToken(redirectTo: String = "tmdb-sdk://auth") async throws(TMDBRequestError) -> Auth
-    .RequestToken {
+    static func createRequestToken(redirectTo: String = "\(TMDB.callbackScheme)://auth") async throws(TMDBRequestError)
+        -> Auth
+        .RequestToken
+    {
         let endpoint = Endpoint<RequestTokenBody, Auth.RequestToken>(
             endpoint: V4Endpoints.Auth.createRequestToken,
             httpMethod: .post,

--- a/Sources/TMDB/Services/AuthService/AuthenticationCoordinator.swift
+++ b/Sources/TMDB/Services/AuthService/AuthenticationCoordinator.swift
@@ -2,6 +2,10 @@ internal import Dependencies
 import Foundation
 
 public extension TMDB {
+    nonisolated static let callbackScheme = "tmdb-sdk"
+}
+
+public extension TMDB {
     actor AuthenticationCoordinator {
         private var inProgress = false
 
@@ -10,7 +14,7 @@ public extension TMDB {
         public init() {}
 
         public func createRequestToken(
-            redirectTo: String = "tmdb-sdk://auth",
+            redirectTo: String = "\(TMDB.callbackScheme)://auth",
         ) async throws(TMDBRequestError) -> (requestToken: String, approvalURL: URL) {
             let result = try await TMDB.createRequestToken(redirectTo: redirectTo)
             let approvalURL = URL(

--- a/Sources/TMDBSwiftUI/TMDBAuthenticationModifier.swift
+++ b/Sources/TMDBSwiftUI/TMDBAuthenticationModifier.swift
@@ -29,7 +29,7 @@ struct TMDBAuthenticationModifier: ViewModifier {
 
             let callbackURL = try await webAuthenticationSession.authenticate(
                 using: approvalURL,
-                callback: .customScheme("tmdb-sdk"),
+                callback: .customScheme(TMDB.callbackScheme),
                 additionalHeaderFields: [:],
             )
 

--- a/Sources/TMDBUIKit/TMDB+UIKitAuth.swift
+++ b/Sources/TMDBUIKit/TMDB+UIKitAuth.swift
@@ -18,7 +18,7 @@ public extension TMDB {
             callbackURL = try await withCheckedThrowingContinuation { continuation in
                 let session = ASWebAuthenticationSession(
                     url: approvalURL,
-                    callback: .customScheme("tmdb-sdk"),
+                    callback: .customScheme(TMDB.callbackScheme),
                     completionHandler: { url, error in
                         if let error {
                             continuation.resume(throwing: error)

--- a/Sources/TMDBUIKit/TMDB+UIKitAuth.swift
+++ b/Sources/TMDBUIKit/TMDB+UIKitAuth.swift
@@ -1,7 +1,7 @@
 import AuthenticationServices
 import TMDB
 
-#if canImport(UIKit)
+#if os(iOS) || targetEnvironment(macCatalyst)
 import UIKit
 
 public extension TMDB {
@@ -15,13 +15,23 @@ public extension TMDB {
 
         let callbackURL: URL
         do {
-            let session = ASWebAuthenticationSession(
-                url: approvalURL,
-                callback: .customScheme("tmdb-sdk"),
-                completionHandler: { _, _ in }, // unused: result handled via session.start() async
-            )
-            session.presentationContextProvider = PresentationContextProvider(anchor: presentationAnchor)
-            callbackURL = try await session.start()
+            callbackURL = try await withCheckedThrowingContinuation { continuation in
+                let session = ASWebAuthenticationSession(
+                    url: approvalURL,
+                    callback: .customScheme("tmdb-sdk"),
+                    completionHandler: { url, error in
+                        if let error {
+                            continuation.resume(throwing: error)
+                        } else if let url {
+                            continuation.resume(returning: url)
+                        } else {
+                            continuation.resume(throwing: URLError(.badServerResponse))
+                        }
+                    },
+                )
+                session.presentationContextProvider = PresentationContextProvider(anchor: presentationAnchor)
+                session.start()
+            }
         } catch {
             let nsError = error as NSError
             if nsError.domain == ASWebAuthenticationSessionError.errorDomain,
@@ -50,4 +60,4 @@ private final class PresentationContextProvider: NSObject, ASWebAuthenticationPr
     }
 }
 
-#endif
+#endif // os(iOS) || targetEnvironment(macCatalyst)

--- a/Sources/TMDBUIKit/TMDB+UIKitAuth.swift
+++ b/Sources/TMDBUIKit/TMDB+UIKitAuth.swift
@@ -18,6 +18,7 @@ public extension TMDB {
             let session = ASWebAuthenticationSession(
                 url: approvalURL,
                 callback: .customScheme("tmdb-sdk"),
+                completionHandler: { _, _ in }, // unused: result handled via session.start() async
             )
             session.presentationContextProvider = PresentationContextProvider(anchor: presentationAnchor)
             callbackURL = try await session.start()


### PR DESCRIPTION
The iOS 26 SDK only exposes init(url:callback:completionHandler:) — the variant without a completion handler isn't available. Add an empty completion handler to satisfy the iOS SDK; the result is handled via session.start() async which supersedes the completion handler path.